### PR TITLE
Add simple macro builder and execution support

### DIFF
--- a/Macros/Starter.py
+++ b/Macros/Starter.py
@@ -1,9 +1,64 @@
 from PySide6.QtWidgets import (
     QApplication, QMainWindow, QListView, QStackedWidget,
-    QFileDialog, QToolBar
+    QFileDialog, QToolBar, QDialog, QVBoxLayout, QPushButton,
+    QListWidget, QInputDialog
 )
 from PySide6.QtGui import QAction
-from PySide6.QtCore import Qt, QAbstractListModel, QModelIndex, Signal
+from PySide6.QtCore import Qt, QAbstractListModel, QModelIndex
+from pathlib import Path
+from Macros.parser import Macro
+
+
+class MacroDialog(QDialog):
+    """Simple dialog to build a macro by adding operation blocks."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Edit Macro")
+        self.macro = Macro("Untitled")
+
+        self.list = QListWidget()
+        btn_click = QPushButton("Add Left Click")
+        btn_move = QPushButton("Add Mouse Move")
+        btn_find = QPushButton("Add Find Image")
+        btn_done = QPushButton("Done")
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.list)
+        layout.addWidget(btn_click)
+        layout.addWidget(btn_move)
+        layout.addWidget(btn_find)
+        layout.addWidget(btn_done)
+
+        btn_click.clicked.connect(self.add_click)
+        btn_move.clicked.connect(self.add_move)
+        btn_find.clicked.connect(self.add_find)
+        btn_done.clicked.connect(self.accept)
+
+    # ------------------------------------------------------------------
+    def add_click(self) -> None:
+        self.macro.left_click()
+        self.list.addItem("Left Click")
+
+    def add_move(self) -> None:
+        x, ok = QInputDialog.getInt(self, "Move", "X coordinate:")
+        if not ok:
+            return
+        y, ok = QInputDialog.getInt(self, "Move", "Y coordinate:")
+        if not ok:
+            return
+        self.macro.move(x, y)
+        self.list.addItem(f"Move to ({x}, {y})")
+
+    def add_find(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select image", str(Path.cwd()), "Images (*.png *.jpg *.bmp)"
+        )
+        if not path:
+            return
+        self.macro.find_image(path)
+        self.list.addItem(f"Find image {Path(path).name}")
+
 
 class MacroModel(QAbstractListModel):
     def __init__(self, macros: list[dict], parent=None):
@@ -35,7 +90,14 @@ class MainWindow(QMainWindow):
         tb.addActions([new_act, save_act])
 
     def new_macro(self):
-        self.model._data.append({"name": "Untitled"})
+        dlg = MacroDialog(self)
+        if not dlg.exec():
+            return
+        folder = QFileDialog.getExistingDirectory(self, "Choose Macro Folder", str(Path.cwd()))
+        if not folder:
+            return
+        dlg.macro.save(folder)
+        self.model._data.append({"name": dlg.macro.name, "path": folder})
         self.model.layoutChanged.emit()
 
     def save_profile(self):

--- a/Macros/deparse.py
+++ b/Macros/deparse.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import time
+
+import pyautogui
+
+
+DEFAULT_PAUSE = 0.1
+
+
+def run(folder: str | Path) -> None:
+    """Load ``macro.json`` from ``folder`` and execute the operations."""
+    folder = Path(folder)
+    data = json.loads((folder / "macro.json").read_text())
+    for op in data.get("ops", []):
+        kind = op.get("op")
+        if kind == "left_click":
+            pyautogui.click(button=op.get("button", "left"))
+        elif kind == "move":
+            pyautogui.moveTo(op.get("x", 0), op.get("y", 0), duration=op.get("duration", 0))
+        elif kind == "find_image":
+            img = folder / op["image"]
+            loc = pyautogui.locateCenterOnScreen(
+                str(img),
+                confidence=op.get("confidence", 0.8),
+                grayscale=op.get("grayscale", True),
+            )
+            if loc:
+                pyautogui.moveTo(loc)
+        time.sleep(op.get("pause", DEFAULT_PAUSE))
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 2:
+        print("Usage: python deparse.py <macro_folder>")
+    else:
+        run(sys.argv[1])
+

--- a/Macros/parser.py
+++ b/Macros/parser.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import List, Dict
+
+
+class Macro:
+    """Helper to build and save macro definitions."""
+
+    def __init__(self, name: str = "macro"):
+        self.name = name
+        self.ops: List[Dict] = []
+        self._assets: Dict[str, Path] = {}
+
+    # --- building blocks -------------------------------------------------
+    def left_click(self) -> "Macro":
+        self.ops.append({"op": "left_click"})
+        return self
+
+    def move(self, x: int, y: int, duration: float = 0.0) -> "Macro":
+        self.ops.append({"op": "move", "x": x, "y": y, "duration": duration})
+        return self
+
+    def find_image(self, image: str, confidence: float = 0.8, grayscale: bool = True) -> "Macro":
+        img_path = Path(image)
+        self.ops.append({
+            "op": "find_image",
+            "image": img_path.name,
+            "confidence": confidence,
+            "grayscale": grayscale,
+        })
+        self._assets[img_path.name] = img_path
+        return self
+
+    # --- serialisation ----------------------------------------------------
+    def save(self, folder: str | Path) -> Path:
+        folder = Path(folder)
+        folder.mkdir(parents=True, exist_ok=True)
+        for name, src in self._assets.items():
+            dst = folder / name
+            if src.resolve() != dst.resolve():
+                shutil.copy(src, dst)
+        data = {"name": self.name, "ops": self.ops}
+        path = folder / "macro.json"
+        path.write_text(json.dumps(data, indent=2))
+        return path
+
+


### PR DESCRIPTION
## Summary
- extend Starter UI with a minimal macro building dialog
- implement `parser.py` for converting UI actions to `macro.json`
- implement `deparse.py` to run macros from JSON folders

## Testing
- `python -m py_compile Macros/Starter.py Macros/parser.py Macros/deparse.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f19ff7958832f833d967f19ea2682