### PR TITLE
Refactor to ratio-only blink features

### DIFF
--- a/Model/data_preparation.py
+++ b/Model/data_preparation.py
@@ -25,11 +25,7 @@ class BlinkSeqDataset(Dataset):
         split_idx = int(len(data_frame) * split_ratio)
         data_frame = data_frame.iloc[:split_idx] if train else data_frame.iloc[split_idx:]
 
-        # ── image patch pixels ───────────────────────────────────────────
-        px_cols = [c for c in data_frame.columns if c.startswith("px_")]
-        X_px = (data_frame[px_cols].values.astype(np.float32) / 255.0).reshape(-1, 1, 24, 12)
-
-        # ── numeric features (EAR etc.) ──────────────────────────────────
+        # ── numeric features -------------------------------------------------
         X_num = data_frame[constants.Data_Gathering_Constants.NUM_COLS].values.astype(
             np.float32
         )
@@ -40,7 +36,6 @@ class BlinkSeqDataset(Dataset):
         X_num = (X_num - mean) / std
 
         # ── tensors & bookkeeping ───────────────────────────────────────
-        self.X_px = torch.from_numpy(X_px)
         self.X_num = torch.from_numpy(X_num)
         self.labels = torch.from_numpy(data_frame["manual_blink"].values.astype(np.int64))
         self.seq_len = seq_len
@@ -52,7 +47,6 @@ class BlinkSeqDataset(Dataset):
 
     def __getitem__(self, idx):
         sl = slice(idx, idx + self.seq_len)
-        eye_seq = self.X_px[sl]  # (seq,1,24,12)
-        num_seq = self.X_num[sl]  # (seq,7)
+        num_seq = self.X_num[sl]  # (seq, num_features)
         label = self.labels[idx + self.seq_len - 1]
-        return eye_seq, num_seq, label
+        return num_seq, label

--- a/Model/model.py
+++ b/Model/model.py
@@ -148,32 +148,25 @@ class BlinkDetectorSmall(nn.Module):
 
 # only uses number data (smallest model)
 class BlinkDetectorXS(nn.Module):
+    """Lightweight numeric-only blink detector."""
+
     def __init__(
         self,
         num_features: int = constants.Model_Constants.NUM_FEATURES,
-        img_height: int = constants.Image_Constants.IM_HEIGHT,
-        img_width: int = constants.Image_Constants.IM_WIDTH,
-        conv_im_channels=constants.Model_Constants.XS_MODEL_CONSTANTS.CONVOLUTIONAL_IMAGE_CHANELS,
+        fc_channels=constants.Model_Constants.XS_MODEL_CONSTANTS.FC_CHANNELS,
         lstm_hidden: int = constants.Model_Constants.XS_MODEL_CONSTANTS.LTSM_HIDDEN,
         lstm_layers: int = constants.Model_Constants.XS_MODEL_CONSTANTS.LTSM_LAYERS,
         bidirectional: bool = constants.Model_Constants.XS_MODEL_CONSTANTS.BIDIRECTIONAL,
     ):
         super().__init__()
-        self.conv_1 = nn.Conv2d(1, conv_im_channels[0], 3, padding=1)
-        self.conv_2 = nn.Conv2d(conv_im_channels[0], conv_im_channels[1], 3, padding=1)
+
         self.relu = nn.ReLU(inplace=True)
-        self.pool = nn.MaxPool2d(2)
-
-        conv_out_h = img_height // 4  # 24 -> 6
-        conv_out_w = img_width // 4  # 12 -> 3
-        flat_dim = conv_out_h * conv_out_w * conv_im_channels[1]
-
-        self.num_fc_1 = nn.Linear(num_features, 64)
-        self.num_fc_2 = nn.Linear(num_features, 32)
-        self.num_fc_3 = nn.Linear(num_features, 16)
+        self.num_fc_1 = nn.Linear(num_features, fc_channels[0])
+        self.num_fc_2 = nn.Linear(fc_channels[0], fc_channels[1])
+        self.num_fc_3 = nn.Linear(fc_channels[1], fc_channels[2])
 
         self.lstm = nn.LSTM(
-            constants.Model_Constants.XS_MODEL_CONSTANTS.LTSM_INPUT_SIZE,
+            fc_channels[2],
             lstm_hidden,
             lstm_layers,
             batch_first=True,
@@ -181,25 +174,19 @@ class BlinkDetectorXS(nn.Module):
         )
         out_dim = lstm_hidden * (2 if bidirectional else 1)
         self.fc = nn.Linear(out_dim, 1)
-
         self.bidirectional = bidirectional
 
-    def forward(self, eye_seq, num_seq):
-        batch, time_steps, channels, height, width = eye_seq.shape
+    def forward(self, num_seq):
+        batch, time_steps, _ = num_seq.shape
+        x = self.relu(self.num_fc_1(num_seq.view(batch * time_steps, -1)))
+        x = self.relu(self.num_fc_2(x))
+        x = self.relu(self.num_fc_3(x))
+        x = x.view(batch, time_steps, -1)
 
-        number_prossesing = self.relu(
-            self.num_fc_1(num_seq.view(batch * time_steps, -1))
+        _, (hidden_states, _) = self.lstm(x)
+        seq_rep = (
+            torch.cat([hidden_states[-2], hidden_states[-1]], dim=1)
+            if self.bidirectional
+            else hidden_states[-1]
         )
-        number_prossesing = self.relu(
-            self.num_fc_2(num_seq.view(batch * time_steps, -1))
-        )
-        number_prossesing = self.relu(
-            self.num_fc_3(num_seq.view(batch * time_steps, -1))
-        )
-
-        _, (hidden_states, _) = self.lstm(number_prossesing)
-        if self.bidirectional:
-            seq_repetition = torch.cat([hidden_states[-2], hidden_states[-1]], dim=1)
-        else:
-            seq_repetition = hidden_states[-1]
-        return self.fc(seq_repetition)
+        return self.fc(seq_rep).squeeze(1)

--- a/Raspberry_Pi_Main.py
+++ b/Raspberry_Pi_Main.py
@@ -1,0 +1,62 @@
+import time
+import cv2 as cv
+import numpy as np
+import bluetooth
+from picamera import PiCamera
+from picamera.array import PiRGBArray
+from cvzone.FaceMeshModule import FaceMeshDetector
+import constants
+
+# Bluetooth server setup
+server_sock = bluetooth.BluetoothSocket(bluetooth.RFCOMM)
+server_sock.bind(("", 1))
+server_sock.listen(1)
+print("Waiting for Bluetooth connection...")
+client_sock, addr = server_sock.accept()
+print("Connected to", addr)
+
+# PiCamera setup
+camera = PiCamera()
+camera.resolution = (640, 480)
+raw_capture = PiRGBArray(camera, size=camera.resolution)
+time.sleep(0.1)
+
+detector = FaceMeshDetector(maxFaces=1)
+
+# helper to compute ratio
+def eye_ratio(face, out_id, in_id, up_id, lo_id):
+    p_out, p_in = face[out_id], face[in_id]
+    p_up, p_lo = face[up_id], face[lo_id]
+    ver, _ = detector.findDistance(p_up, p_lo)
+    hor, _ = detector.findDistance(p_out, p_in)
+    return ver / hor if hor else 0.0
+
+try:
+    for frame in camera.capture_continuous(raw_capture, format="bgr", use_video_port=True):
+        img = frame.array
+        img = cv.resize(img, (img.shape[1] // 2, img.shape[0] // 2))
+        img, faces = detector.findFaceMesh(img, draw=False)
+        if faces:
+            face = faces[0]
+            ratio_L = eye_ratio(
+                face,
+                constants.Image_Constants.LEFT_EYE_OUT_ID,
+                constants.Image_Constants.LEFT_EYE_INSIDE_ID,
+                constants.Image_Constants.LEFT_EYE_UP_ID,
+                constants.Image_Constants.LEFT_EYE_LOW_ID,
+            )
+            ratio_R = eye_ratio(
+                face,
+                constants.Image_Constants.RIGHT_EYE_OUT_ID,
+                constants.Image_Constants.RIGHT_EYE_INSIDE_ID,
+                constants.Image_Constants.RIGHT_EYE_UP_ID,
+                constants.Image_Constants.RIGHT_EYE_LOW_ID,
+            )
+            msg = f"{ratio_L:.4f},{ratio_R:.4f}\n"
+            client_sock.send(msg.encode())
+        raw_capture.truncate(0)
+except KeyboardInterrupt:
+    pass
+finally:
+    client_sock.close()
+    server_sock.close()

--- a/constants.py
+++ b/constants.py
@@ -55,20 +55,19 @@ class Data_Gathering_Constants:
     BLINK_PRE_FRAMES = 3
     BLINK_POST_FRAMES = 6
 
+    # Features recorded for every frame
+    # Using only the ratio of vertical eye height over
+    # horizontal eye width for the left and right eye
     NUM_COLS = [
         "ratio_left",
         "ratio_right",
-        "ratio_avg",
-        "v_left",
-        "h_left",
-        "v_right",
-        "h_right",
     ]
 
 
 # Constants for different models
 class Model_Constants:
-    NUM_FEATURES = 7
+    # Number of numeric features per frame (ratio for both eyes)
+    NUM_FEATURES = 2
 
     class MEDIUM_MODEL_CONSTANTS:
         CONVOLUTIONAL_IMAGE_CHANELS = (16, 64, 32)
@@ -89,12 +88,11 @@ class Model_Constants:
         BIDIRECTIONAL = True
 
     class XS_MODEL_CONSTANTS:
-        CONVOLUTIONAL_IMAGE_CHANELS = (16, 24)
-        CONVOLUTIONAL_NUMERIC_CHANELS = (24, 16)
-        IMAGE_OUTPUT_SIZE = 64
-        LTSM_INPUT_SIZE = IMAGE_OUTPUT_SIZE + CONVOLUTIONAL_NUMERIC_CHANELS[-1]
-        LTSM_HIDDEN = 32
-        LTSM_LAYERS = 1
+        # Number-only model with a slightly larger capacity
+        FC_CHANNELS = (128, 64, 32)
+        LTSM_INPUT_SIZE = FC_CHANNELS[-1]
+        LTSM_HIDDEN = 64
+        LTSM_LAYERS = 2
         BIDIRECTIONAL = False
 
 

--- a/data/data_factory.py
+++ b/data/data_factory.py
@@ -1,50 +1,40 @@
-import time, cv2 as cv, cvzone as cvz, numpy as np, pandas as pd, keyboard
+import time
+import cv2 as cv
+import cvzone as cvz
+import numpy as np
+import pandas as pd
+import keyboard
 from cvzone.FaceMeshModule import FaceMeshDetector
 from cvzone.PlotModule import LivePlot
 import constants
 
-# --------------- constants ----------------
-WIDTH_IM, HEIGHT_IM = 24, 12  # size of each eye patch
+# CSV output
 CSV_NAME = f"blink_data_{time.strftime('%Y%m%d_%H%M%S')}.csv"
 
-# Label‑window padding (frames) ---------
-BLINK_PRE_FRAMES = 3  # frames before key‑press set to 1
-BLINK_POST_FRAMES = 6  # frames after key‑press set to 1
+# Label window parameters
+BLINK_PRE_FRAMES = constants.Data_Gathering_Constants.BLINK_PRE_FRAMES
+BLINK_POST_FRAMES = constants.Data_Gathering_Constants.BLINK_POST_FRAMES
 
-# --------------- helpers ------------------
+# ----- helpers ---------------------------------------------------------------
 
+def eye_ratio(face, out_id, in_id, up_id, lo_id):
+    """Return vertical/horizontal eye ratio."""
+    p_out, p_in = face[out_id], face[in_id]
+    p_up, p_lo = face[up_id], face[lo_id]
+    ver, _ = detector.findDistance(p_up, p_lo)
+    hor, _ = detector.findDistance(p_out, p_in)
+    return ver / hor if hor else 0.0
 
-def eye_aspect_ratio(face, out_id, in_id, up_id, lo_id):
-
-    p_out = face[out_id]
-    p_in = face[in_id]
-    p_up = face[up_id]
-    p_lo = face[lo_id]
-    ver = detector.findDistance(p_up, p_lo)[0]
-    hor = detector.findDistance(p_out, p_in)[0]
-    return (ver / hor) * 10, ver, hor
-
-
-def eye_patch(img, pts):
-    """Return a greyscale crop around the provided eye landmarks."""
-    x, y, w, h = cv.boundingRect(pts)
-    patch = cv.cvtColor(img[y : y + h, x : x + w], cv.COLOR_BGR2GRAY)
-    if patch.size == 0:
-        return np.zeros(
-            (constants.Image_Constants.IM_HEIGHT, constants.Image_Constants.IM_WIDTH),
-            np.uint8,
-        )
-    return cv.resize(
-        patch,
-        (constants.Image_Constants.IM_WIDTH, constants.Image_Constants.IM_HEIGHT),
-        interpolation=cv.INTER_AREA,
-    )
-
-
-# --------------- init ---------------------
+# ----- init -----------------------------------------------------------------
 cap = cv.VideoCapture(0)
+# use half resolution to avoid warped frames
+w = int(cap.get(cv.CAP_PROP_FRAME_WIDTH) // 2)
+h = int(cap.get(cv.CAP_PROP_FRAME_HEIGHT) // 2)
+cap.set(cv.CAP_PROP_FRAME_WIDTH, w)
+cap.set(cv.CAP_PROP_FRAME_HEIGHT, h)
+
 detector = FaceMeshDetector(maxFaces=1)
-plot = LivePlot(640, 360, [1, 4])  # ratio plot
+plot = LivePlot(640, 360, [0, 0.4])
 
 data_rows = []
 blink_count = 0
@@ -61,20 +51,15 @@ try:
         img, faces = detector.findFaceMesh(img, draw=False)
         keypress_now = keyboard.is_pressed("space")
 
-        # -------- blink edge detection --------
-        if keypress_now and not prev_keypress:  # rising edge
+        # ---- blink edge detection ----
+        if keypress_now and not prev_keypress:
             blink_count += 1
             blink_post_ctr = BLINK_POST_FRAMES
-
-            # retroactively label previous frames
             for i in range(1, BLINK_PRE_FRAMES + 1):
                 if len(data_rows) >= i:
                     data_rows[-i]["manual_blink"] = 1
 
-        # decide label for this frame
         manual_blink = int(keypress_now or blink_post_ctr > 0)
-
-        # countdown post window
         if blink_post_ctr:
             blink_post_ctr -= 1
 
@@ -82,20 +67,17 @@ try:
 
         if faces:
             face = faces[0]
-
-            # draw landmarks used
             for pid in constants.Image_Constants.ID_ARRAYS:
-                cv.circle(img, face[pid], 4, (255, 0, 255), cv.FILLED)
+                cv.circle(img, face[pid], 3, (255, 0, 255), cv.FILLED)
 
-            # ratio for left / right
-            ratio_L, vL, hL = eye_aspect_ratio(
+            ratio_L = eye_ratio(
                 face,
                 constants.Image_Constants.LEFT_EYE_OUT_ID,
                 constants.Image_Constants.LEFT_EYE_INSIDE_ID,
                 constants.Image_Constants.LEFT_EYE_UP_ID,
                 constants.Image_Constants.LEFT_EYE_LOW_ID,
             )
-            ratio_R, vR, hR = eye_aspect_ratio(
+            ratio_R = eye_ratio(
                 face,
                 constants.Image_Constants.RIGHT_EYE_OUT_ID,
                 constants.Image_Constants.RIGHT_EYE_INSIDE_ID,
@@ -104,132 +86,43 @@ try:
             )
             ratio_avg = (ratio_L + ratio_R) / 2
 
-            # eye patches
-            pts_left = np.array(
-                [
-                    face[id]
-                    for id in [
-                        constants.Image_Constants.LEFT_EYE_OUT_ID,
-                        constants.Image_Constants.LEFT_EYE_INSIDE_ID,
-                        constants.Image_Constants.LEFT_EYE_UP_ID,
-                        constants.Image_Constants.LEFT_EYE_LOW_ID,
-                    ]
-                ],
-                np.int32,
-            )
-            pts_right = np.array(
-                [
-                    face[id]
-                    for id in [
-                        constants.Image_Constants.RIGHT_EYE_OUT_ID,
-                        constants.Image_Constants.RIGHT_EYE_INSIDE_ID,
-                        constants.Image_Constants.RIGHT_EYE_UP_ID,
-                        constants.Image_Constants.RIGHT_EYE_LOW_ID,
-                    ]
-                ],
-                np.int32,
-            )
-            patch_left = eye_patch(img, pts_left)
-            patch_right = eye_patch(img, pts_right)
-            pixels_left = patch_left.flatten().tolist()
-            pixels_right = patch_right.flatten().tolist()
-
-            # HUD
-            cv.putText(
-                img,
-                f"Blink #: {blink_count}",
-                (20, 35),
-                cv.FONT_HERSHEY_SIMPLEX,
-                1.5,
-                (0, 255, 0),
-                2,
-            )
-            cv.putText(
-                img,
-                f"EAR L/R: {ratio_L:.2f}/{ratio_R:.2f}",
-                (20, 65),
-                cv.FONT_HERSHEY_SIMPLEX,
-                1.5,
-                (0, 255, 0),
-                2,
-            )
+            cv.putText(img, f"Blink #: {blink_count}", (20, 35), cv.FONT_HERSHEY_SIMPLEX, 1.0, (0, 255, 0), 2)
+            cv.putText(img, f"Ratio L/R: {ratio_L:.2f}/{ratio_R:.2f}", (20, 65), cv.FONT_HERSHEY_SIMPLEX, 1.0, (0, 255, 0), 2)
             if manual_blink:
-                cv.putText(
-                    img,
-                    "BLINK (label=1)",
-                    (20, 95),
-                    cv.FONT_HERSHEY_SIMPLEX,
-                    0.7,
-                    (0, 0, 255),
-                    2,
+                cv.putText(img, "BLINK (label=1)", (20, 95), cv.FONT_HERSHEY_SIMPLEX, 0.7, (0, 0, 255), 2)
+
+            img_plot = plot.update(ratio_avg)
+            img_stack = cvz.stackImages([cv.resize(img, (640, 360)), img_plot], 2, 1)
+            cv.imshow("Blink Recorder", img_stack)
+
+            data_rows.append(
+                dict(
+                    timestamp=timestamp,
+                    ratio_left=ratio_L,
+                    ratio_right=ratio_R,
+                    blink_count=blink_count,
+                    manual_blink=manual_blink,
                 )
-
-            # plot & show
-            plot_img = plot.update(ratio_avg)
-            show_stack = cvz.stackImages([cv.resize(img, (640, 360)), plot_img], 2, 1)
-            cv.imshow("Blink Recorder", show_stack)
-            cv.imshow("Left Eye", patch_left)
-            cv.imshow("Right Eye", patch_right)
-
-            # ---------- record row ----------
-            row = dict(
-                timestamp=timestamp,
-                ratio_left=ratio_L,
-                ratio_right=ratio_R,
-                ratio_avg=ratio_avg,
-                v_left=vL,
-                h_left=hL,
-                v_right=vR,
-                h_right=hR,
-                blink_count=blink_count,
-                manual_blink=manual_blink,
             )
-            row.update({f"px_l_{i}": pix for i, pix in enumerate(pixels_left)})
-            row.update({f"px_r_{i}": pix for i, pix in enumerate(pixels_right)})
-            data_rows.append(row)
-
         else:
-            # still write a row to keep timeline (pixels = NaNs)
             data_rows.append(
                 dict(
                     timestamp=timestamp,
                     ratio_left=None,
                     ratio_right=None,
-                    ratio_avg=None,
-                    v_left=None,
-                    h_left=None,
-                    v_right=None,
-                    h_right=None,
                     blink_count=blink_count,
                     manual_blink=manual_blink,
-                    **{
-                        f"px_l_{i}": None
-                        for i in range(
-                            constants.Image_Constants.IM_WIDTH
-                            * constants.Image_Constants.IM_HEIGHT
-                        )
-                    },
-                    **{
-                        f"px_r_{i}": None
-                        for i in range(
-                            constants.Image_Constants.IM_WIDTH
-                            * constants.Image_Constants.IM_HEIGHT
-                        )
-                    },
                 )
             )
             cv.imshow("Blink Recorder", cv.resize(img, (640, 360)))
-            cv.imshow("Left Eye", np.zeros((HEIGHT_IM, WIDTH_IM), np.uint8))
-            cv.imshow("Right Eye", np.zeros((HEIGHT_IM, WIDTH_IM), np.uint8))
 
         if cv.waitKey(1) & 0xFF == ord("q"):
             break
 
         prev_keypress = keypress_now
-
 finally:
     if data_rows:
         pd.DataFrame(data_rows).to_csv(CSV_NAME, index=False)
-        print(f"Saved {len(data_rows)} rows → {CSV_NAME}")
+        print(f"Saved {len(data_rows)} rows -> {CSV_NAME}")
     cap.release()
     cv.destroyAllWindows()

--- a/main.py
+++ b/main.py
@@ -14,13 +14,13 @@ from constants import (
     BLINKING_THREASHOLD,
     Image_Constants,
     Training_Constnats,
+    Model_Constants,
 )
-from Model.model import BlinkModelMed as model  # adjust import path if needed
+from Model.model import BlinkDetectorXS as model  # numeric-only model
 
 # ───────── configuration ──────────────────────────────────────
 SEQ_LEN = Training_Constnats.SEQUENCE_LENGTH
-PATCH_W = Image_Constants.IM_WIDTH
-PATCH_H = Image_Constants.IM_HEIGHT
+NUM_FEATURES = Model_Constants.NUM_FEATURES
 
 THRESH = BLINKING_THREASHOLD
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
@@ -46,15 +46,7 @@ def ear(face, out_id, in_id, up_id, lo_id, det):
     p_up, p_lo = face[up_id], face[lo_id]
     ver, _ = det.findDistance(p_up, p_lo)
     hor, _ = det.findDistance(p_out, p_in)
-    return (ver / hor) * 10, ver, hor
-
-
-def eye_patch(img, pts):
-    x, y, w, h = cv.boundingRect(pts)
-    patch = cv.cvtColor(img[y : y + h, x : x + w], cv.COLOR_BGR2GRAY)
-    if patch.size == 0:
-        return np.zeros((PATCH_H, PATCH_W), np.uint8)
-    return cv.resize(patch, (PATCH_W, PATCH_H), interpolation=cv.INTER_AREA)
+    return ver / hor, ver, hor
 
 
 # --------------------------------------------------------------
@@ -64,11 +56,11 @@ model = model().to(DEVICE).eval()
 model.load_state_dict(torch.load(MODEL_WEIGHTS, map_location=DEVICE))
 
 stats = np.load(STATS_NPZ)
-MEAN, STD = stats["mean"], stats["std"]  # (7,) each
+MEAN, STD = stats["mean"], stats["std"]  # (NUM_FEATURES,) each
 # --------------------------------------------------------------
 
 # ---------- runtime buffers -----------------------------------
-eye_buf, num_buf = [], []  # hold SEQ_LEN frames
+num_buf = []  # hold SEQ_LEN frames
 blink_count = 0
 prev_pred = 0
 # --------------------------------------------------------------
@@ -99,35 +91,24 @@ while True:
             cv.circle(img, face[pid], 3, (255, 0, 255), cv.FILLED)
 
         # ── numeric features
-        ratio_L, vL, hL = ear(face, L_OUT, L_IN, L_UP, L_LO, detector)
-        ratio_R, vR, hR = ear(face, R_OUT, R_IN, R_UP, R_LO, detector)
+        ratio_L, _, _ = ear(face, L_OUT, L_IN, L_UP, L_LO, detector)
+        ratio_R, _, _ = ear(face, R_OUT, R_IN, R_UP, R_LO, detector)
         ratio_avg = (ratio_L + ratio_R) / 2
-        num_feats = np.array(
-            [ratio_L, ratio_R, ratio_avg, vL, hL, vR, hR], dtype=np.float32
-        )
-
-        # ── eye patch (left eye)
-        pts_left = np.array([face[id_] for id_ in (L_OUT, L_IN, L_UP, L_LO)], np.int32)
-        patch = eye_patch(img, pts_left).T.astype(np.float32) / 255.0  # (24,12)
+        num_feats = np.array([ratio_L, ratio_R], dtype=np.float32)
 
         # add to buffers
-        eye_buf.append(patch[None])  # (1,24,12)
         num_buf.append(num_feats)
-        if len(eye_buf) > SEQ_LEN:
-            eye_buf.pop(0)
         if len(num_buf) > SEQ_LEN:
             num_buf.pop(0)
 
         # run model when window full
-        if len(eye_buf) == SEQ_LEN:
-            eye_arr = np.stack(eye_buf)  # (SEQ_LEN,1,24,12)
+        if len(num_buf) == SEQ_LEN:
             num_arr = (np.stack(num_buf) - MEAN) / STD  # z‑score
 
-            eye_t = torch.from_numpy(eye_arr)[None].to(DEVICE)  # (1,SEQ_LEN,1,24,12)
-            num_t = torch.from_numpy(num_arr)[None].to(DEVICE)  # (1,SEQ_LEN,7)
+            num_t = torch.from_numpy(num_arr)[None].to(DEVICE)  # (1,SEQ_LEN,NUM_FEATURES)
 
             with torch.no_grad():
-                p = torch.sigmoid(model(eye_t, num_t)).item()
+                p = torch.sigmoid(model(num_t)).item()
 
             pred = int(p > THRESH)
             if pred == 1 and prev_pred == 0:  # count rising edge


### PR DESCRIPTION
## Summary
- track only left/right eye aspect ratios in the collector
- adjust constants and LSTM model for numeric-only input
- simplify dataset and training script
- update main program to work with new features
- add Raspberry_Pi_Main for Bluetooth streaming from Pi

## Testing
- `python -m py_compile constants.py Model/model.py Model/train_blink.py Model/data_preparation.py main.py Raspberry_Pi_Main.py data/data_factory.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bluetooth')*

------
https://chatgpt.com/codex/tasks/task_e_684f31886ff0832f9fc5eb26b7e43d18