### PR TITLE
Refactor to ratio-only blink model

### DIFF
--- a/Model/model.py
+++ b/Model/model.py
@@ -203,3 +203,43 @@ class BlinkDetectorXS(nn.Module):
         else:
             seq_repetition = hidden_states[-1]
         return self.fc(seq_repetition)
+
+
+class BlinkRatioNet(nn.Module):
+    """LSTM-based classifier using only EAR ratios."""
+
+    def __init__(
+        self,
+        num_features: int = constants.Model_Constants.NUM_FEATURES,
+        fc_sizes = constants.Model_Constants.RATIO_MODEL_CONSTANTS.FC_SIZES,
+        lstm_hidden: int = constants.Model_Constants.RATIO_MODEL_CONSTANTS.LTSM_HIDDEN,
+        lstm_layers: int = constants.Model_Constants.RATIO_MODEL_CONSTANTS.LTSM_LAYERS,
+        bidirectional: bool = constants.Model_Constants.RATIO_MODEL_CONSTANTS.BIDIRECTIONAL,
+    ):
+        super().__init__()
+        self.layers = nn.ModuleList()
+        in_dim = num_features
+        for s in fc_sizes:
+            self.layers.append(nn.Linear(in_dim, s))
+            in_dim = s
+        self.relu = nn.ReLU(inplace=True)
+        self.lstm = nn.LSTM(
+            in_dim,
+            lstm_hidden,
+            lstm_layers,
+            batch_first=True,
+            bidirectional=bidirectional,
+        )
+        out_dim = lstm_hidden * (2 if bidirectional else 1)
+        self.out_fc = nn.Linear(out_dim, 1)
+        self.bidirectional = bidirectional
+
+    def forward(self, num_seq):
+        batch, time_steps, _ = num_seq.shape
+        x = num_seq.view(batch * time_steps, -1)
+        for fc in self.layers:
+            x = self.relu(fc(x))
+        x = x.view(batch, time_steps, -1)
+        _, (h, _) = self.lstm(x)
+        h = torch.cat([h[-2], h[-1]], dim=1) if self.bidirectional else h[-1]
+        return self.out_fc(h).squeeze(1)

--- a/Model/train_blink.py
+++ b/Model/train_blink.py
@@ -7,7 +7,7 @@ from torch.utils.data import Dataset, DataLoader
 from torch.amp.autocast_mode import autocast
 from torch.amp.grad_scaler import GradScaler
 from sklearn.metrics import accuracy_score, precision_recall_fscore_support
-from model import BlinkDetectorXS as BlinkDetector
+from model import BlinkRatioNet as BlinkDetector
 import constants
 
 
@@ -25,10 +25,7 @@ if not os.path.exists(CSV_PATH):
 
 class BlinkSeqDataset(Dataset):
 
-    NUM_COLS = [
-        "ratio_left", "ratio_right", "ratio_avg",
-        "v_left", "h_left", "v_right", "h_right",
-    ]
+    NUM_COLS = constants.Data_Gathering_Constants.NUM_COLS
 
     def __init__(self, csv_path: str, seq_len: int = 50, *, train: bool = True,
                  split_ratio: float = 0.6, numeric_stats=None):
@@ -41,11 +38,7 @@ class BlinkSeqDataset(Dataset):
         split_idx = int(len(df) * split_ratio)
         df = df.iloc[:split_idx] if train else df.iloc[split_idx:]
 
-        # ── image patch pixels ───────────────────────────────────────────
-        px_cols = [c for c in df.columns if c.startswith("px_")]
-        X_px = (df[px_cols].values.astype(np.float32) / 255.0).reshape(-1, 1, 24, 12)
-
-        # ── numeric features (EAR etc.) ──────────────────────────────────
+        # ── numeric features (EAR ratios) ───────────────────────────────
         X_num = df[self.NUM_COLS].values.astype(np.float32)
         if numeric_stats is None:  # compute stats from *training* split only
             mean, std = X_num.mean(axis=0), X_num.std(axis=0) + 1e-6
@@ -54,7 +47,6 @@ class BlinkSeqDataset(Dataset):
         X_num = (X_num - mean) / std
 
         # ── tensors & bookkeeping ───────────────────────────────────────
-        self.X_px      = torch.from_numpy(X_px)
         self.X_num     = torch.from_numpy(X_num)
         self.labels    = torch.from_numpy(df["manual_blink"].values.astype(np.int64))
         self.seq_len   = seq_len
@@ -66,10 +58,9 @@ class BlinkSeqDataset(Dataset):
 
     def __getitem__(self, idx):
         sl = slice(idx, idx + self.seq_len)
-        eye_seq = self.X_px[sl]    # (seq,1,24,12)
-        num_seq = self.X_num[sl]   # (seq,7)
+        num_seq = self.X_num[sl]
         label   = self.labels[idx + self.seq_len - 1]
-        return eye_seq, num_seq, label
+        return num_seq, label
 
 # ── build datasets & loaders ─────────────────────────────────────────────
 train_ds = BlinkSeqDataset(CSV_PATH, seq_len=SEQ_LEN, train=True)
@@ -103,13 +94,12 @@ def run_epoch(loader, *, training: bool):
     model.train() if training else model.eval()
     loss_sum, y_pred_all, y_true_all = 0.0, [], []
 
-    for eye, num, lbl in loader:
-        eye = eye.to(device, non_blocking=pin).float()
+    for num, lbl in loader:
         num = num.to(device, non_blocking=pin).float()
         lbl = lbl.to(device, non_blocking=pin).float()
 
         with autocast(device_type = device):
-            logits = model(eye, num)
+            logits = model(num)
             loss   = criterion(logits, lbl)
 
         if training:
@@ -162,21 +152,19 @@ if os.path.exists("blink_best.pth"):
     model.eval()
 
 
-def predict_sequence(eye_seq_np: np.ndarray, num_seq_np: np.ndarray) -> float:
+def predict_sequence(num_seq_np: np.ndarray) -> float:
     """Return blink probability for a *single* sequence (no batching).
 
     Parameters
     ----------
-    eye_seq_np : ndarray (T,1,24,12) float32 in [0,1]
-    num_seq_np : ndarray (T,7)        float32 *already z‑scored*
+    num_seq_np : ndarray (T,N) float32 *already z‑scored*
     """
-    assert eye_seq_np.shape[0] == num_seq_np.shape[0] == SEQ_LEN, "wrong seq len"
+    assert num_seq_np.shape[0] == SEQ_LEN, "wrong seq len"
 
-    eye = torch.from_numpy(eye_seq_np).unsqueeze(0).to(device)
     num = torch.from_numpy(num_seq_np).unsqueeze(0).to(device)
 
     with torch.no_grad(), autocast(device_type = device):
-        prob = torch.sigmoid(model(eye, num)).item()
+        prob = torch.sigmoid(model(num)).item()
     return prob
 
 # -------------------------------------------------------------------------

--- a/Raspberry_Pi_Main.py
+++ b/Raspberry_Pi_Main.py
@@ -1,0 +1,62 @@
+import time
+import cv2 as cv
+import bluetooth
+from picamera import PiCamera
+from picamera.array import PiRGBArray
+from cvzone.FaceMeshModule import FaceMeshDetector
+import constants
+
+BT_ADDR = "B8:27:EB:C2:A5:45"  # adjust for your receiver
+
+L_IDS = (
+    constants.Image_Constants.LEFT_EYE_OUT_ID,
+    constants.Image_Constants.LEFT_EYE_INSIDE_ID,
+    constants.Image_Constants.LEFT_EYE_UP_ID,
+    constants.Image_Constants.LEFT_EYE_LOW_ID,
+)
+R_IDS = (
+    constants.Image_Constants.RIGHT_EYE_OUT_ID,
+    constants.Image_Constants.RIGHT_EYE_INSIDE_ID,
+    constants.Image_Constants.RIGHT_EYE_UP_ID,
+    constants.Image_Constants.RIGHT_EYE_LOW_ID,
+)
+
+def eye_ratio(face, ids, det):
+    p_out, p_in, p_up, p_lo = [face[i] for i in ids]
+    ver, _ = det.findDistance(p_up, p_lo)
+    hor, _ = det.findDistance(p_out, p_in)
+    return ver / (hor + 1e-6)
+
+# --- setup camera ---
+camera = PiCamera()
+# use half resolution to avoid warped capture
+width, height = camera.resolution
+camera.resolution = (width // 2, height // 2)
+raw = PiRGBArray(camera, size=camera.resolution)
+
+# --- bluetooth ---
+sock = bluetooth.BluetoothSocket(bluetooth.RFCOMM)
+sock.connect((BT_ADDR, 1))
+
+# --- face mesh ---
+detector = FaceMeshDetector(maxFaces=1)
+
+time.sleep(2.0)
+
+try:
+    for frame in camera.capture_continuous(raw, format="bgr", use_video_port=True):
+        img = frame.array
+        raw.truncate(0)
+        img, faces = detector.findFaceMesh(img, draw=False)
+        if faces:
+            face = faces[0]
+            ratio_L = eye_ratio(face, L_IDS, detector)
+            ratio_R = eye_ratio(face, R_IDS, detector)
+            msg = f"{ratio_L:.4f},{ratio_R:.4f}\n"
+            sock.send(msg.encode())
+        if cv.waitKey(1) & 0xFF == ord('q'):
+            break
+finally:
+    sock.close()
+    camera.close()
+

--- a/constants.py
+++ b/constants.py
@@ -58,17 +58,12 @@ class Data_Gathering_Constants:
     NUM_COLS = [
         "ratio_left",
         "ratio_right",
-        "ratio_avg",
-        "v_left",
-        "h_left",
-        "v_right",
-        "h_right",
     ]
 
 
 # Constants for different models
 class Model_Constants:
-    NUM_FEATURES = 7
+    NUM_FEATURES = 2
 
     class MEDIUM_MODEL_CONSTANTS:
         CONVOLUTIONAL_IMAGE_CHANELS = (16, 64, 32)
@@ -96,6 +91,13 @@ class Model_Constants:
         LTSM_HIDDEN = 32
         LTSM_LAYERS = 1
         BIDIRECTIONAL = False
+
+    class RATIO_MODEL_CONSTANTS:
+        FC_SIZES = (64, 64, 32)
+        LTSM_INPUT_SIZE = FC_SIZES[-1]
+        LTSM_HIDDEN = 64
+        LTSM_LAYERS = 2
+        BIDIRECTIONAL = True
 
 
 class Training_Constnats:

--- a/data/data_factory.py
+++ b/data/data_factory.py
@@ -1,55 +1,51 @@
-import time, cv2 as cv, cvzone as cvz, numpy as np, pandas as pd, keyboard
+import time
+import cv2 as cv
+import cvzone as cvz
+import numpy as np
+import pandas as pd
+import keyboard
 from cvzone.FaceMeshModule import FaceMeshDetector
 from cvzone.PlotModule import LivePlot
 import constants
 
-# --------------- constants ----------------
-WIDTH_IM, HEIGHT_IM = 24, 12  # size of each eye patch
 CSV_NAME = f"blink_data_{time.strftime('%Y%m%d_%H%M%S')}.csv"
 
-# Label‑window padding (frames) ---------
-BLINK_PRE_FRAMES = 3  # frames before key‑press set to 1
-BLINK_POST_FRAMES = 6  # frames after key‑press set to 1
-
-# --------------- helpers ------------------
-
-
-def eye_aspect_ratio(face, out_id, in_id, up_id, lo_id):
-
-    p_out = face[out_id]
-    p_in = face[in_id]
-    p_up = face[up_id]
-    p_lo = face[lo_id]
-    ver = detector.findDistance(p_up, p_lo)[0]
-    hor = detector.findDistance(p_out, p_in)[0]
-    return (ver / hor) * 10, ver, hor
-
-
-def eye_patch(img, pts):
-    """Return a greyscale crop around the provided eye landmarks."""
-    x, y, w, h = cv.boundingRect(pts)
-    patch = cv.cvtColor(img[y : y + h, x : x + w], cv.COLOR_BGR2GRAY)
-    if patch.size == 0:
-        return np.zeros(
-            (constants.Image_Constants.IM_HEIGHT, constants.Image_Constants.IM_WIDTH),
-            np.uint8,
-        )
-    return cv.resize(
-        patch,
-        (constants.Image_Constants.IM_WIDTH, constants.Image_Constants.IM_HEIGHT),
-        interpolation=cv.INTER_AREA,
-    )
-
-
-# --------------- init ---------------------
 cap = cv.VideoCapture(0)
+# fix camera warping by halving default resolution
+w = int(cap.get(cv.CAP_PROP_FRAME_WIDTH) // 2)
+h = int(cap.get(cv.CAP_PROP_FRAME_HEIGHT) // 2)
+cap.set(cv.CAP_PROP_FRAME_WIDTH, w)
+cap.set(cv.CAP_PROP_FRAME_HEIGHT, h)
+
+BLINK_PRE = constants.Data_Gathering_Constants.BLINK_PRE_FRAMES
+BLINK_POST = constants.Data_Gathering_Constants.BLINK_POST_FRAMES
+
+L_IDS = (
+    constants.Image_Constants.LEFT_EYE_OUT_ID,
+    constants.Image_Constants.LEFT_EYE_INSIDE_ID,
+    constants.Image_Constants.LEFT_EYE_UP_ID,
+    constants.Image_Constants.LEFT_EYE_LOW_ID,
+)
+R_IDS = (
+    constants.Image_Constants.RIGHT_EYE_OUT_ID,
+    constants.Image_Constants.RIGHT_EYE_INSIDE_ID,
+    constants.Image_Constants.RIGHT_EYE_UP_ID,
+    constants.Image_Constants.RIGHT_EYE_LOW_ID,
+)
+
+def eye_ratio(face, ids, det):
+    p_out, p_in, p_up, p_lo = [face[i] for i in ids]
+    ver, _ = det.findDistance(p_up, p_lo)
+    hor, _ = det.findDistance(p_out, p_in)
+    return ver / (hor + 1e-6)
+
 detector = FaceMeshDetector(maxFaces=1)
-plot = LivePlot(640, 360, [1, 4])  # ratio plot
+plot = LivePlot(640, 360, [0.5, 3])
 
 data_rows = []
 blink_count = 0
-blink_post_ctr = 0
-prev_keypress = False
+post_ctr = 0
+prev_key = False
 t0 = time.time()
 
 try:
@@ -59,177 +55,57 @@ try:
             break
 
         img, faces = detector.findFaceMesh(img, draw=False)
-        keypress_now = keyboard.is_pressed("space")
+        key_now = keyboard.is_pressed("space")
 
-        # -------- blink edge detection --------
-        if keypress_now and not prev_keypress:  # rising edge
+        if key_now and not prev_key:
             blink_count += 1
-            blink_post_ctr = BLINK_POST_FRAMES
-
-            # retroactively label previous frames
-            for i in range(1, BLINK_PRE_FRAMES + 1):
+            post_ctr = BLINK_POST
+            for i in range(1, BLINK_PRE + 1):
                 if len(data_rows) >= i:
                     data_rows[-i]["manual_blink"] = 1
 
-        # decide label for this frame
-        manual_blink = int(keypress_now or blink_post_ctr > 0)
-
-        # countdown post window
-        if blink_post_ctr:
-            blink_post_ctr -= 1
+        manual_blink = int(key_now or post_ctr > 0)
+        if post_ctr:
+            post_ctr -= 1
 
         timestamp = time.time() - t0
 
         if faces:
             face = faces[0]
-
-            # draw landmarks used
             for pid in constants.Image_Constants.ID_ARRAYS:
-                cv.circle(img, face[pid], 4, (255, 0, 255), cv.FILLED)
-
-            # ratio for left / right
-            ratio_L, vL, hL = eye_aspect_ratio(
-                face,
-                constants.Image_Constants.LEFT_EYE_OUT_ID,
-                constants.Image_Constants.LEFT_EYE_INSIDE_ID,
-                constants.Image_Constants.LEFT_EYE_UP_ID,
-                constants.Image_Constants.LEFT_EYE_LOW_ID,
-            )
-            ratio_R, vR, hR = eye_aspect_ratio(
-                face,
-                constants.Image_Constants.RIGHT_EYE_OUT_ID,
-                constants.Image_Constants.RIGHT_EYE_INSIDE_ID,
-                constants.Image_Constants.RIGHT_EYE_UP_ID,
-                constants.Image_Constants.RIGHT_EYE_LOW_ID,
-            )
-            ratio_avg = (ratio_L + ratio_R) / 2
-
-            # eye patches
-            pts_left = np.array(
-                [
-                    face[id]
-                    for id in [
-                        constants.Image_Constants.LEFT_EYE_OUT_ID,
-                        constants.Image_Constants.LEFT_EYE_INSIDE_ID,
-                        constants.Image_Constants.LEFT_EYE_UP_ID,
-                        constants.Image_Constants.LEFT_EYE_LOW_ID,
-                    ]
-                ],
-                np.int32,
-            )
-            pts_right = np.array(
-                [
-                    face[id]
-                    for id in [
-                        constants.Image_Constants.RIGHT_EYE_OUT_ID,
-                        constants.Image_Constants.RIGHT_EYE_INSIDE_ID,
-                        constants.Image_Constants.RIGHT_EYE_UP_ID,
-                        constants.Image_Constants.RIGHT_EYE_LOW_ID,
-                    ]
-                ],
-                np.int32,
-            )
-            patch_left = eye_patch(img, pts_left)
-            patch_right = eye_patch(img, pts_right)
-            pixels_left = patch_left.flatten().tolist()
-            pixels_right = patch_right.flatten().tolist()
-
-            # HUD
-            cv.putText(
-                img,
-                f"Blink #: {blink_count}",
-                (20, 35),
-                cv.FONT_HERSHEY_SIMPLEX,
-                1.5,
-                (0, 255, 0),
-                2,
-            )
-            cv.putText(
-                img,
-                f"EAR L/R: {ratio_L:.2f}/{ratio_R:.2f}",
-                (20, 65),
-                cv.FONT_HERSHEY_SIMPLEX,
-                1.5,
-                (0, 255, 0),
-                2,
-            )
-            if manual_blink:
-                cv.putText(
-                    img,
-                    "BLINK (label=1)",
-                    (20, 95),
-                    cv.FONT_HERSHEY_SIMPLEX,
-                    0.7,
-                    (0, 0, 255),
-                    2,
-                )
-
-            # plot & show
-            plot_img = plot.update(ratio_avg)
-            show_stack = cvz.stackImages([cv.resize(img, (640, 360)), plot_img], 2, 1)
-            cv.imshow("Blink Recorder", show_stack)
-            cv.imshow("Left Eye", patch_left)
-            cv.imshow("Right Eye", patch_right)
-
-            # ---------- record row ----------
+                cv.circle(img, face[pid], 3, (255, 0, 255), cv.FILLED)
+            ratio_L = eye_ratio(face, L_IDS, detector)
+            ratio_R = eye_ratio(face, R_IDS, detector)
             row = dict(
                 timestamp=timestamp,
                 ratio_left=ratio_L,
                 ratio_right=ratio_R,
-                ratio_avg=ratio_avg,
-                v_left=vL,
-                h_left=hL,
-                v_right=vR,
-                h_right=hR,
                 blink_count=blink_count,
                 manual_blink=manual_blink,
             )
-            row.update({f"px_l_{i}": pix for i, pix in enumerate(pixels_left)})
-            row.update({f"px_r_{i}": pix for i, pix in enumerate(pixels_right)})
             data_rows.append(row)
-
+            plot_img = plot.update((ratio_L + ratio_R) / 2)
+            stack = cvz.stackImages([cv.resize(img, (640, 360)), plot_img], 2, 1)
+            cv.imshow("Blink Recorder", stack)
         else:
-            # still write a row to keep timeline (pixels = NaNs)
             data_rows.append(
                 dict(
                     timestamp=timestamp,
                     ratio_left=None,
                     ratio_right=None,
-                    ratio_avg=None,
-                    v_left=None,
-                    h_left=None,
-                    v_right=None,
-                    h_right=None,
                     blink_count=blink_count,
                     manual_blink=manual_blink,
-                    **{
-                        f"px_l_{i}": None
-                        for i in range(
-                            constants.Image_Constants.IM_WIDTH
-                            * constants.Image_Constants.IM_HEIGHT
-                        )
-                    },
-                    **{
-                        f"px_r_{i}": None
-                        for i in range(
-                            constants.Image_Constants.IM_WIDTH
-                            * constants.Image_Constants.IM_HEIGHT
-                        )
-                    },
                 )
             )
             cv.imshow("Blink Recorder", cv.resize(img, (640, 360)))
-            cv.imshow("Left Eye", np.zeros((HEIGHT_IM, WIDTH_IM), np.uint8))
-            cv.imshow("Right Eye", np.zeros((HEIGHT_IM, WIDTH_IM), np.uint8))
 
         if cv.waitKey(1) & 0xFF == ord("q"):
             break
-
-        prev_keypress = keypress_now
-
+        prev_key = key_now
 finally:
     if data_rows:
         pd.DataFrame(data_rows).to_csv(CSV_NAME, index=False)
         print(f"Saved {len(data_rows)} rows → {CSV_NAME}")
     cap.release()
     cv.destroyAllWindows()
+

--- a/main.py
+++ b/main.py
@@ -15,12 +15,10 @@ from constants import (
     Image_Constants,
     Training_Constnats,
 )
-from Model.model import BlinkModelMed as model  # adjust import path if needed
+from Model.model import BlinkRatioNet as model
 
 # ───────── configuration ──────────────────────────────────────
 SEQ_LEN = Training_Constnats.SEQUENCE_LENGTH
-PATCH_W = Image_Constants.IM_WIDTH
-PATCH_H = Image_Constants.IM_HEIGHT
 
 THRESH = BLINKING_THREASHOLD
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
@@ -46,15 +44,7 @@ def ear(face, out_id, in_id, up_id, lo_id, det):
     p_up, p_lo = face[up_id], face[lo_id]
     ver, _ = det.findDistance(p_up, p_lo)
     hor, _ = det.findDistance(p_out, p_in)
-    return (ver / hor) * 10, ver, hor
-
-
-def eye_patch(img, pts):
-    x, y, w, h = cv.boundingRect(pts)
-    patch = cv.cvtColor(img[y : y + h, x : x + w], cv.COLOR_BGR2GRAY)
-    if patch.size == 0:
-        return np.zeros((PATCH_H, PATCH_W), np.uint8)
-    return cv.resize(patch, (PATCH_W, PATCH_H), interpolation=cv.INTER_AREA)
+    return ver / (hor + 1e-6)
 
 
 # --------------------------------------------------------------
@@ -64,11 +54,11 @@ model = model().to(DEVICE).eval()
 model.load_state_dict(torch.load(MODEL_WEIGHTS, map_location=DEVICE))
 
 stats = np.load(STATS_NPZ)
-MEAN, STD = stats["mean"], stats["std"]  # (7,) each
+MEAN, STD = stats["mean"], stats["std"]
 # --------------------------------------------------------------
 
 # ---------- runtime buffers -----------------------------------
-eye_buf, num_buf = [], []  # hold SEQ_LEN frames
+num_buf = []  # hold SEQ_LEN frames
 blink_count = 0
 prev_pred = 0
 # --------------------------------------------------------------
@@ -99,35 +89,22 @@ while True:
             cv.circle(img, face[pid], 3, (255, 0, 255), cv.FILLED)
 
         # ── numeric features
-        ratio_L, vL, hL = ear(face, L_OUT, L_IN, L_UP, L_LO, detector)
-        ratio_R, vR, hR = ear(face, R_OUT, R_IN, R_UP, R_LO, detector)
+        ratio_L = ear(face, L_OUT, L_IN, L_UP, L_LO, detector)
+        ratio_R = ear(face, R_OUT, R_IN, R_UP, R_LO, detector)
         ratio_avg = (ratio_L + ratio_R) / 2
-        num_feats = np.array(
-            [ratio_L, ratio_R, ratio_avg, vL, hL, vR, hR], dtype=np.float32
-        )
+        num_feats = np.array([ratio_L, ratio_R], dtype=np.float32)
 
-        # ── eye patch (left eye)
-        pts_left = np.array([face[id_] for id_ in (L_OUT, L_IN, L_UP, L_LO)], np.int32)
-        patch = eye_patch(img, pts_left).T.astype(np.float32) / 255.0  # (24,12)
-
-        # add to buffers
-        eye_buf.append(patch[None])  # (1,24,12)
         num_buf.append(num_feats)
-        if len(eye_buf) > SEQ_LEN:
-            eye_buf.pop(0)
         if len(num_buf) > SEQ_LEN:
             num_buf.pop(0)
 
         # run model when window full
-        if len(eye_buf) == SEQ_LEN:
-            eye_arr = np.stack(eye_buf)  # (SEQ_LEN,1,24,12)
-            num_arr = (np.stack(num_buf) - MEAN) / STD  # z‑score
-
-            eye_t = torch.from_numpy(eye_arr)[None].to(DEVICE)  # (1,SEQ_LEN,1,24,12)
-            num_t = torch.from_numpy(num_arr)[None].to(DEVICE)  # (1,SEQ_LEN,7)
+        if len(num_buf) == SEQ_LEN:
+            num_arr = (np.stack(num_buf) - MEAN) / STD
+            num_t = torch.from_numpy(num_arr)[None].to(DEVICE)
 
             with torch.no_grad():
-                p = torch.sigmoid(model(eye_t, num_t)).item()
+                p = torch.sigmoid(model(num_t)).item()
 
             pred = int(p > THRESH)
             if pred == 1 and prev_pred == 0:  # count rising edge


### PR DESCRIPTION
## Summary
- simplify numeric feature list to left/right EAR ratios
- capture new features in `data_factory.py` and fix camera warp
- overhaul dataset and training code for numeric-only sequences
- implement new `BlinkRatioNet` model
- update desktop runtime and add `Raspberry_Pi_Main` for Pi camera streaming

## Testing
- `python -m py_compile constants.py data/data_factory.py Model/data_preparation.py Model/model.py Model/train_blink.py main.py Raspberry_Pi_Main.py`

------
https://chatgpt.com/codex/tasks/task_e_684f31886ff0832f9fc5eb26b7e43d18