### PR TITLE
Extend eye metrics

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -58,12 +58,16 @@ class Data_Gathering_Constants:
     NUM_COLS = [
         "ratio_left",
         "ratio_right",
+        "height_left",
+        "height_right",
+        "width_left",
+        "width_right",
     ]
 
 
 # Constants for different models
 class Model_Constants:
-    NUM_FEATURES = 2
+    NUM_FEATURES = 6
 
     class RATIO_MODEL_CONSTANTS:
         FC_SIZES = (64, 64, 32)

--- a/data/data_factory.py
+++ b/data/data_factory.py
@@ -38,11 +38,13 @@ R_IDS = (
     constants.Image_Constants.RIGHT_EYE_LOW_ID,
 )
 
-def eye_ratio(face, ids, det):
+def eye_metrics(face, ids, det):
+    """Return EAR ratio along with vertical and horizontal distances."""
     p_out, p_in, p_up, p_lo = [face[i] for i in ids]
     ver, _ = det.findDistance(p_up, p_lo)
     hor, _ = det.findDistance(p_out, p_in)
-    return ver / (hor + 1e-6)
+    ratio = ver / (hor + 1e-6)
+    return ratio, ver, hor
 
 detector = FaceMeshDetector(maxFaces=1)
 plot = LivePlot(640, 360, [0, 0.5])
@@ -89,12 +91,16 @@ try:
             face = faces[0]
             for pid in constants.Image_Constants.ID_ARRAYS:
                 cv.circle(img, face[pid], 3, (255, 0, 255), cv.FILLED)
-            ratio_L = eye_ratio(face, L_IDS, detector)
-            ratio_R = eye_ratio(face, R_IDS, detector)
+            ratio_L, ver_L, hor_L = eye_metrics(face, L_IDS, detector)
+            ratio_R, ver_R, hor_R = eye_metrics(face, R_IDS, detector)
             row = dict(
                 timestamp=timestamp,
                 ratio_left=ratio_L,
                 ratio_right=ratio_R,
+                height_left=ver_L,
+                height_right=ver_R,
+                width_left=hor_L,
+                width_right=hor_R,
                 blink_count=blink_count,
                 manual_blink=manual_blink,
             )
@@ -108,6 +114,10 @@ try:
                     timestamp=timestamp,
                     ratio_left=None,
                     ratio_right=None,
+                    height_left=None,
+                    height_right=None,
+                    width_left=None,
+                    width_right=None,
                     blink_count=blink_count,
                     manual_blink=manual_blink,
                 )

--- a/main.py
+++ b/main.py
@@ -39,12 +39,14 @@ POINTS_USED = Image_Constants.ID_ARRAYS
 
 # ---------- helper functions (copied from collector) ----------
 
-def ear(face, out_id, in_id, up_id, lo_id, det):
+def eye_metrics(face, out_id, in_id, up_id, lo_id, det):
+    """Return EAR ratio with vertical and horizontal distances."""
     p_out, p_in = face[out_id], face[in_id]
     p_up, p_lo = face[up_id], face[lo_id]
     ver, _ = det.findDistance(p_up, p_lo)
     hor, _ = det.findDistance(p_out, p_in)
-    return ver / (hor + 1e-6)
+    ratio = ver / (hor + 1e-6)
+    return ratio, ver, hor
 
 
 # --------------------------------------------------------------
@@ -89,10 +91,12 @@ while True:
             cv.circle(img, face[pid], 3, (255, 0, 255), cv.FILLED)
 
         # ── numeric features
-        ratio_L = ear(face, L_OUT, L_IN, L_UP, L_LO, detector)
-        ratio_R = ear(face, R_OUT, R_IN, R_UP, R_LO, detector)
+        ratio_L, ver_L, hor_L = eye_metrics(face, L_OUT, L_IN, L_UP, L_LO, detector)
+        ratio_R, ver_R, hor_R = eye_metrics(face, R_OUT, R_IN, R_UP, R_LO, detector)
         ratio_avg = (ratio_L + ratio_R) / 2
-        num_feats = np.array([ratio_L, ratio_R], dtype=np.float32)
+        num_feats = np.array(
+            [ratio_L, ratio_R, ver_L, ver_R, hor_L, hor_R], dtype=np.float32
+        )
 
         num_buf.append(num_feats)
         if len(num_buf) > SEQ_LEN:


### PR DESCRIPTION
## Summary
- collect additional eye height and width measurements
- store new metrics in training constants
- update inference to use the new features

## Testing
- `python -m py_compile constants.py data/data_factory.py Model/data_preparation.py Model/model.py Model/train_blink.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68501dc839bc832f99344868316cfdad