### PR TITLE
Add model dropdown and update model paths

### DIFF
--- a/Model/train_blink.py
+++ b/Model/train_blink.py
@@ -100,8 +100,8 @@ for epoch in range(1, 101):
     if va_f1 > best_f1 + 1e-3 and va_f1 > CURR_BEST_F1:
         best_f1 = va_f1
         no_improve = 0
-        torch.save(model.state_dict(), "blink_best.pth")
-        np.savez("blink_stats.npz", mean=train_ds.stats[0], std=train_ds.stats[1])
+        torch.save(model.state_dict(), constants.Paths.NUM_WEIGHTS)
+        np.savez(constants.Paths.NUM_STATS_NPZ, mean=train_ds.stats[0], std=train_ds.stats[1])
         print("✓ Saved new best model & stats (F1 ↑)")
     else:
         no_improve += 1
@@ -112,8 +112,8 @@ for epoch in range(1, 101):
 # -------------------------------------------------------------------------
 # ---------- BLOCK 6 : Inference helper ----------------------------------
 # Load best weights (helpful after an early stop during interactive runs)
-if os.path.exists("blink_best.pth"):
-    model.load_state_dict(torch.load("blink_best.pth", map_location=device))
+if os.path.exists(constants.Paths.NUM_WEIGHTS):
+    model.load_state_dict(torch.load(constants.Paths.NUM_WEIGHTS, map_location=device))
     model.eval()
 
 

--- a/constants.py
+++ b/constants.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 
 
-MODEL_WEIGHTS = "blink_best.pth"
-STATS_NPZ = "blink_stats.npz"
+# Default blink detection model (numeric ratios)
+# Updated to new location inside dev/models and dev/stats
+MODEL_WEIGHTS = str(Path("dev/models/blink_num_best.pth"))
+STATS_NPZ = str(Path("dev/stats/blink_num_stats.npz"))
 BLINKING_THREASHOLD = 0.50
 EYE_IMAGE_SIZE = 32  # width for legacy compatibility
 

--- a/main.py
+++ b/main.py
@@ -9,8 +9,7 @@ from cvzone.FaceMeshModule import FaceMeshDetector
 from cvzone.PlotModule import LivePlot
 
 from constants import (
-    MODEL_WEIGHTS,
-    STATS_NPZ,
+    Paths,
     BLINKING_THREASHOLD,
     Image_Constants,
     Training_Constants,
@@ -65,9 +64,9 @@ def vertical_ratios(face, pairs, out_id, in_id, det):
 
 # ---------- load model & feature stats ------------------------
 model = model().to(DEVICE).eval()
-model.load_state_dict(torch.load(MODEL_WEIGHTS, map_location=DEVICE))
+model.load_state_dict(torch.load(Paths.NUM_WEIGHTS, map_location=DEVICE))
 
-stats = np.load(STATS_NPZ)
+stats = np.load(Paths.NUM_STATS_NPZ)
 MEAN, STD = stats["mean"], stats["std"]
 # --------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- allow choosing between numeric and eye-image models via dropdown
- load models from new `dev/models` paths
- update statistics file paths

## Testing
- `python -m py_compile on_device_full.py main.py Model/train_blink.py Model/train_eye.py Model/model.py constants.py`

------
https://chatgpt.com/codex/tasks/task_e_68532083fa24832fb6dffa073819d25f