### PR TITLE
Improve capture threading and inference speed

### DIFF
--- a/Model/train_blink.py
+++ b/Model/train_blink.py
@@ -128,7 +128,7 @@ def predict_sequence(num_seq_np: np.ndarray) -> float:
 
     num = torch.from_numpy(num_seq_np).unsqueeze(0).to(device)
 
-    with torch.no_grad(), autocast(device_type = device):
+    with torch.inference_mode(), autocast(device_type = device):
         prob = torch.sigmoid(model(num)).item()
     return prob
 

--- a/Model/train_eye.py
+++ b/Model/train_eye.py
@@ -104,6 +104,6 @@ if os.path.exists(constants.Paths.IMG_WEIGHTS):
 def predict_sequence(img_seq_np: np.ndarray) -> float:
     assert img_seq_np.shape[0] == SEQ_LEN, "wrong seq len"
     img = torch.from_numpy(img_seq_np).unsqueeze(0).to(device)
-    with torch.no_grad(), autocast(device_type=device):
+    with torch.inference_mode(), autocast(device_type=device):
         prob = torch.sigmoid(model(img)).item()
     return prob


### PR DESCRIPTION
## Summary
- start a separate `FrameGrabberThread` to avoid blocking the UI
- grab frames with FFMPEG backend and minimal buffering
- normalise tensors on device and use correct row stride when converting
- stop the grabber thread on window close

## Testing
- `python -m py_compile app.py on_device_full.py main.py Model/train_blink.py Model/train_eye.py`


------
https://chatgpt.com/codex/tasks/task_e_6855bcfe6e0c832f9089065216a8ee62